### PR TITLE
APOLLO-3275 Compile with 5.x.  Add appendables to response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ project(":") {
 
   //create a single Jar with the jackson dependencies
   task fatJar(type: Jar) {
-    baseName = "solr-plugins-for-fusion"
+    baseName = "solr-${solrClientVersion}-plugins-for-fusion"
     from { configurations.releaseJars.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
   }

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ project(":") {
     // include these libs with the release jar
     releaseJars "org.codehaus.jackson:jackson-core-asl:1.9.13"
     releaseJars "org.codehaus.jackson:jackson-mapper-asl:1.9.13"
+
+    testCompile group: 'junit', name: 'junit', version: '4.+'
   }
 
   //create a single Jar with the jackson dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=com.lucidworks.solr.fusion
-version=0.1-alpha.1
+version=0.2
 
-solrClientVersion=4.10.4
+solrClientVersion=5.2.0
 
 # Build properties
 javacSource=1.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=com.lucidworks.solr.fusion
-version=0.2
+version=0.2-SNAPSHOT
 
-solrClientVersion=5.2.0
+solrClientVersion=5.0.0
 
 # Build properties
 javacSource=1.6

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##############################################################################
 ##
@@ -61,9 +61,9 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/"
+cd "`dirname \"$PRG\"`/" >&-
 APP_HOME="`pwd -P`"
-cd "$SAVED"
+cd "$SAVED" >&-
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -101,7 +101,7 @@ if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
             warn "Could not set maximum file descriptor limit: $MAX_FD"
         fi
     else
-        warn "Could not query businessSystem maximum file descriptor limit: $MAX_FD_LIMIT"
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
     fi
 fi
 

--- a/src/main/java/com/lucidworks/log4j/README.txt
+++ b/src/main/java/com/lucidworks/log4j/README.txt
@@ -1,0 +1,1 @@
+TODO: create a log4j appender that sends to searchlogs, tie that in with bin/solr start, tada

--- a/src/main/java/com/lucidworks/solr/fusion/LogToFusionComponent.java
+++ b/src/main/java/com/lucidworks/solr/fusion/LogToFusionComponent.java
@@ -171,13 +171,18 @@ public class LogToFusionComponent extends SearchComponent{
 
     // create the searchEvent
     Map<String, Object> searchEvent = new HashMap<String, Object>();
+
     if (isDistrib) {
       searchEvent.put("numFound", getNumDocsDistrib(rb));
     } else {
       searchEvent.put("numFound", getNumDocsNonDistrib(rb));
     }
     searchEvent.put("QTime", getQTime(rb));
+
     NamedList<Object> namedList = req.getParams().toNamedList();
+    namedList.add("path", req.getContext().get("path"));
+    namedList.add("httpMethod", req.getContext().get("httpMethod"));
+    // TODO: could also dig into HttpServletRequest from `sreq.getContext().put("httpRequest", req);` in SolrRequestParsers
     searchEvent.put("queryParams", toMultiMap(namedList));
 
 

--- a/src/test/java/com/lucidworks/solr/fusion/FusionQPSearchComponentTest.java
+++ b/src/test/java/com/lucidworks/solr/fusion/FusionQPSearchComponentTest.java
@@ -1,0 +1,44 @@
+package com.lucidworks.solr.fusion;
+
+import junit.framework.TestCase;
+import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+
+import java.util.ArrayList;
+
+public class FusionQPSearchComponentTest extends TestCase {
+  public void testFusionResponseProcessing() throws Exception {
+    String typicalFusionResponse = "{ \n" +
+        "   \"fusion\" :  {\n" +
+        "         \"query-params\":  {\n" +
+        "              \"extra\": [\"test\"],\n" +
+        "              \"extrarray\": [\"test1\",\"test2\"]\n" +
+        "         },\n" +
+        "         \"landing-pages\":  [\n" +
+        "              \"www.lucidworks.com\"\n" +
+        "         ]\n" +
+        "    }\n" +
+        "}";
+
+
+    SolrQueryRequest req = new LocalSolrQueryRequest(null, new NamedList());
+    SolrQueryResponse rsp = new SolrQueryResponse();
+
+    FusionQPSearchComponent.overlayFusionData(typicalFusionResponse, req, rsp);
+
+    // test query params made it to the request
+    SolrParams p = req.getParams();
+    assertEquals("test", p.getParams("extra")[0]);
+    assertEquals("test1", p.getParams("extrarray")[0]);
+    assertEquals("test2", p.getParams("extrarray")[1]);
+
+    // check that everything else passed through into the response
+    NamedList nl = rsp.getValues();
+    ArrayList landingPages = (ArrayList)((NamedList)nl.get("fusion")).get("landing-pages");
+    assertNotNull(landingPages);
+    assertEquals("www.lucidworks.com", landingPages.get(0));
+  }
+}


### PR DESCRIPTION
* Any appendables from the Fusion response other than 'query-params' are added to the Solr response.
* This is useful for features like landing pages etc..
* Added a JUnit test 

Improvements by @erikhatcher. 